### PR TITLE
feat: adding subDirectory functionality in the commands list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ $ zip-build --help
   #                   from your package.json file (eg: name, version,
   #                   license, description, author, etc.)
   #                   [string] [default: %NAME%_%VERSION%_%TIMESTAMP%.%EXT%]
+  #    -s, --subDir   Creates a directory inside the zip file where all
+  #                   files gonna be
+  #                   [string] [default: '']
   #
   #  Examples:
   #  (1) Using defaults:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "inquirer": "^8.2.0",
     "yargs": "^16.2.0",
-    "zip-folder-promise": "^1.1.0"
+    "zip-folder-promise": "^1.2.0"
   },
   "devDependencies": {
     "@types/inquirer": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zip-build",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Node package to zip your build directory and name it according to your package.json name and version.",
   "homepage": "https://github.com/tribal2/zip-build#readme",
   "author": "Ricardo Tribaldos (https://barustudio.com)",

--- a/src/handler.spec.ts
+++ b/src/handler.spec.ts
@@ -27,6 +27,7 @@ const ARGS: IArguments = {
   zipDir: 'build',
   format: 'zip',
   name: false,
+  subDir: 'public',
   template: '%NAME%_%VERSION%_%TIMESTAMP%.%EXT%',
 };
 
@@ -47,7 +48,8 @@ test('Create backup archive with default values', async () => {
     .toHaveBeenCalledWith(
       BUILDPATH,
       OUTPATH,
-      ARGS.format
+      ARGS.format,
+      ARGS.subDir
     );
 });
 
@@ -99,6 +101,7 @@ test('Ask user for output file name', async () => {
     .toHaveBeenCalledWith(
       BUILDPATH,
       OUTPATH,
-      ARGS.format
+      ARGS.format,
+      ARGS.subDir
     );
 });

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -15,6 +15,7 @@ export default async function handler({
   buildDir,   // 'build'
   zipDir,     // 'dist'
   format,     // 'zip'
+  subDir,     // 'subdirectory'
   name,       // false
   template,   // '%NAME%_%VERSION%_%TIMESTAMP%.%EXT%'
 }: IArguments): Promise<void> {
@@ -67,7 +68,7 @@ export default async function handler({
       outUri = path.join(OUTPATH, newOutfileName);
     }
 
-    const resMsg = await zipFolderPromise(BUILDPATH, outUri, format);
+    const resMsg = await zipFolderPromise(BUILDPATH, outUri, format, subDir);
     console.log(`${resMsg} to ${outUri}`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ function builder(yargs: Argv) {
       default: '%NAME%_%VERSION%_%TIMESTAMP%.%EXT%',
     })
     .option('subDir', {
-      alias: 'sd',
+      alias: 's',
       type: 'string',
       description: 'Set a subdirectory in the zip file',
       default: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export interface IArguments extends Arguments {
   format: TFormat;
   name: boolean;
   template: string;
+  subDir: string;
 }
 
 function builder(yargs: Argv) {
@@ -45,6 +46,12 @@ function builder(yargs: Argv) {
       type: 'string',
       description: 'Template for output archive filename',
       default: '%NAME%_%VERSION%_%TIMESTAMP%.%EXT%',
+    })
+    .option('subDir', {
+      alias: 'sd',
+      type: 'string',
+      description: 'Set a subdirectory in the zip file',
+      default: '',
     })
     .example('$0', "Zip 'build' directory and put archive under dist directory.")
     .example('$0 out backup', "Zip 'out' directory and put archive under backup directory.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function builder(yargs: Argv) {
     .option('subDir', {
       alias: 's',
       type: 'string',
-      description: 'Set a subdirectory in the zip file',
+      description: 'Creates a sub directory to put all files',
       default: '',
     })
     .example('$0', "Zip 'build' directory and put archive under dist directory.")


### PR DESCRIPTION
 - Add subDirectory as option in the commands list (as it has been added in the "zip-folder-promise" dependency)
 - Update the version of the depency project zip-folder-promise (1.2.0) to support the subDirectory creation
 - Increment subDirectory in the tests params